### PR TITLE
Add MagTek card parsing

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,4 +24,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hidapi = "2.4"
 lazy_static = "1.5.0"
+regex = "1"
 


### PR DESCRIPTION
## Summary
- parse ID and name from MagTek swipe data using regex
- expose parsed `magtek-data` event with serialized data
- add `regex` crate dependency

## Testing
- `npm run build`
- `cargo check` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6857a8278cb0832bab3c159419b1f05d